### PR TITLE
Add the implementation of Gridding reverse (arXiv 2006.03761)

### DIFF
--- a/cuda/include/chamfer_dist.h
+++ b/cuda/include/chamfer_dist.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <torch/extension.h>
 #include <vector>
 

--- a/cuda/include/cubic_feature_sampling.h
+++ b/cuda/include/cubic_feature_sampling.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <vector>
 
 #include <ATen/cuda/CUDAContext.h>

--- a/cuda/include/gridding.h
+++ b/cuda/include/gridding.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <vector>
 
 #include <ATen/cuda/CUDAContext.h>

--- a/cuda/include/gridding_reverse.h
+++ b/cuda/include/gridding_reverse.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <vector>
 
 #include <ATen/cuda/CUDAContext.h>

--- a/cuda/include/gridding_reverse.h
+++ b/cuda/include/gridding_reverse.h
@@ -1,0 +1,14 @@
+#include <vector>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <torch/extension.h>
+
+torch::Tensor gridding_reverse_kernel_warpper(int scale, torch::Tensor grid, cudaStream_t stream);
+
+torch::Tensor gridding_reverse_grad_kernel_warpper(torch::Tensor ptcloud, torch::Tensor grid,
+                                                   torch::Tensor grad_ptcloud, cudaStream_t stream);
+
+torch::Tensor gridding_reverse(int scale, torch::Tensor grid);
+
+torch::Tensor gridding_reverse_grad(torch::Tensor ptcloud, torch::Tensor grid,
+                                    torch::Tensor grad_ptcloud);

--- a/cuda/src/bindings.cpp
+++ b/cuda/src/bindings.cpp
@@ -2,6 +2,7 @@
 #include "chamfer_dist.h"
 #include "cubic_feature_sampling.h"
 #include "gridding.h"
+#include "gridding_reverse.h"
 #include "interpolate.h"
 #include "metrics.h"
 #include "sampling.h"
@@ -27,4 +28,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
 
     m.def("gridding", &gridding);
     m.def("gridding_grad", &gridding_grad);
+
+    m.def("gridding_reverse", &gridding_reverse);
+    m.def("gridding_reverse_grad", &gridding_reverse_grad);
 }

--- a/cuda/src/gridding_reverse.cpp
+++ b/cuda/src/gridding_reverse.cpp
@@ -1,0 +1,25 @@
+#include "gridding_reverse.h"
+#include "utils.h"
+
+torch::Tensor gridding_reverse(int scale, torch::Tensor grid)
+{
+    CHECK_CUDA(grid);
+    CHECK_CONTIGUOUS(grid);
+
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+    return gridding_reverse_kernel_warpper(scale, grid, stream);
+}
+
+torch::Tensor gridding_reverse_grad(torch::Tensor ptcloud, torch::Tensor grid,
+                                    torch::Tensor grad_ptcloud)
+{
+    CHECK_CUDA(ptcloud);
+    CHECK_CONTIGUOUS(ptcloud);
+    CHECK_CUDA(grid);
+    CHECK_CONTIGUOUS(grid);
+    CHECK_CUDA(grad_ptcloud);
+    CHECK_CONTIGUOUS(grad_ptcloud);
+
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+    return gridding_reverse_grad_kernel_warpper(ptcloud, grid, grad_ptcloud, stream);
+}

--- a/cuda/src/gridding_reverse_gpu.cu
+++ b/cuda/src/gridding_reverse_gpu.cu
@@ -1,0 +1,330 @@
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <torch/extension.h>
+
+#include "cuda_utils.h"
+
+#define CUDA_NUM_THREADS 512
+
+// Computer the number of threads needed in GPU
+inline int get_n_threads(int n)
+{
+    const int pow_2 = std::log(static_cast<float>(n)) / std::log(2.0);
+    return max(min(1 << pow_2, CUDA_NUM_THREADS), 1);
+}
+
+__device__ int compute_index(int offset_x, int offset_y, int offset_z, int len_y, int len_z)
+{
+    return offset_x * len_y * len_z + offset_y * len_z + offset_z;
+}
+
+template <typename scalar_t> __device__ scalar_t compute_weight(scalar_t x, scalar_t x0)
+{
+    return 1 - abs(x - x0);
+}
+
+template <typename scalar_t>
+__global__ void
+gridding_kernel(int n_grid_vertices, int n_pts, float min_x, float min_y, float min_z, int len_y,
+                int len_z, const scalar_t* __restrict__ ptcloud,
+                scalar_t* __restrict__ grid_weights, scalar_t* __restrict__ grid_pt_weights,
+                int* __restrict__ grid_pt_indexes)
+{
+    int batch_index = blockIdx.x;
+    int index = threadIdx.x;
+    int stride = blockDim.x;
+
+    ptcloud += batch_index * n_pts * 3;
+    grid_weights += batch_index * n_grid_vertices;
+    grid_pt_weights += batch_index * n_pts * 24;
+    grid_pt_indexes += batch_index * n_pts * 8;
+
+    for (int j = index; j < n_pts; j += stride)
+    {
+        scalar_t pt_x = ptcloud[j * 3 + 0];
+        scalar_t pt_y = ptcloud[j * 3 + 1];
+        scalar_t pt_z = ptcloud[j * 3 + 2];
+
+        int lower_x = std::floor(pt_x);
+        int upper_x = std::ceil(pt_x);
+        if (lower_x == upper_x)
+        {
+            upper_x += 1;
+        }
+        int lower_y = std::floor(pt_y);
+        int upper_y = std::ceil(pt_y);
+        if (lower_y == upper_y)
+        {
+            upper_y += 1;
+        }
+        int lower_z = std::floor(pt_z);
+        int upper_z = std::ceil(pt_z);
+        if (lower_z == upper_z)
+        {
+            upper_z += 1;
+        }
+
+        int lx_offset = lower_x - min_x, ux_offset = upper_x - min_x;
+        int ly_offset = lower_y - min_y, uy_offset = upper_y - min_y;
+        int lz_offset = lower_z - min_z, uz_offset = upper_z - min_z;
+
+        // Compute weights and corresponding positions, a loop for 8 points
+        // LLL -> Lower X, Lower Y, Lower Z
+        grid_pt_indexes[j * 8 + 0] = compute_index(lx_offset, ly_offset, lz_offset, len_y, len_z);
+        grid_pt_weights[j * 24 + 0] = compute_weight<scalar_t>(pt_x, lower_x);
+        grid_pt_weights[j * 24 + 1] = compute_weight<scalar_t>(pt_y, lower_y);
+        grid_pt_weights[j * 24 + 2] = compute_weight<scalar_t>(pt_z, lower_z);
+
+        // LLU -> Lower X, Lower Y, Upper Z
+        grid_pt_indexes[j * 8 + 1] = compute_index(lx_offset, ly_offset, uz_offset, len_y, len_z);
+        grid_pt_weights[j * 24 + 3] = compute_weight<scalar_t>(pt_x, lower_x);
+        grid_pt_weights[j * 24 + 4] = compute_weight<scalar_t>(pt_y, lower_y);
+        grid_pt_weights[j * 24 + 5] = compute_weight<scalar_t>(pt_z, upper_z);
+
+        // LUL -> Lower X, Upper Y, Lower Z
+        grid_pt_indexes[j * 8 + 2] = compute_index(lx_offset, uy_offset, lz_offset, len_y, len_z);
+        grid_pt_weights[j * 24 + 6] = compute_weight<scalar_t>(pt_x, lower_x);
+        grid_pt_weights[j * 24 + 7] = compute_weight<scalar_t>(pt_y, upper_y);
+        grid_pt_weights[j * 24 + 8] = compute_weight<scalar_t>(pt_z, lower_z);
+
+        // LUU -> Lower X, Upper Y, Upper Z
+        grid_pt_indexes[j * 8 + 3] = compute_index(lx_offset, uy_offset, uz_offset, len_y, len_z);
+        grid_pt_weights[j * 24 + 9] = compute_weight<scalar_t>(pt_x, lower_x);
+        grid_pt_weights[j * 24 + 10] = compute_weight<scalar_t>(pt_y, upper_y);
+        grid_pt_weights[j * 24 + 11] = compute_weight<scalar_t>(pt_z, upper_z);
+
+        // ULL -> Upper X, Lower Y, Lower Z
+        grid_pt_indexes[j * 8 + 4] = compute_index(ux_offset, ly_offset, lz_offset, len_y, len_z);
+        grid_pt_weights[j * 24 + 12] = compute_weight<scalar_t>(pt_x, upper_x);
+        grid_pt_weights[j * 24 + 13] = compute_weight<scalar_t>(pt_y, lower_y);
+        grid_pt_weights[j * 24 + 14] = compute_weight<scalar_t>(pt_z, lower_z);
+
+        // ULU -> Upper X, Lower Y, Upper Z
+        grid_pt_indexes[j * 8 + 5] = compute_index(ux_offset, ly_offset, uz_offset, len_y, len_z);
+        grid_pt_weights[j * 24 + 15] = compute_weight<scalar_t>(pt_x, upper_x);
+        grid_pt_weights[j * 24 + 16] = compute_weight<scalar_t>(pt_y, lower_y);
+        grid_pt_weights[j * 24 + 17] = compute_weight<scalar_t>(pt_z, upper_z);
+
+        // UUL -> Upper X, Upper Y, Lower Z
+        grid_pt_indexes[j * 8 + 6] = compute_index(ux_offset, uy_offset, lz_offset, len_y, len_z);
+        grid_pt_weights[j * 24 + 18] = compute_weight<scalar_t>(pt_x, upper_x);
+        grid_pt_weights[j * 24 + 19] = compute_weight<scalar_t>(pt_y, upper_y);
+        grid_pt_weights[j * 24 + 20] = compute_weight<scalar_t>(pt_z, lower_z);
+
+        // UUU -> Upper X, Upper Y, Upper Z
+        grid_pt_indexes[j * 8 + 7] = compute_index(ux_offset, uy_offset, uz_offset, len_y, len_z);
+        grid_pt_weights[j * 24 + 21] = compute_weight<scalar_t>(pt_x, upper_x);
+        grid_pt_weights[j * 24 + 22] = compute_weight<scalar_t>(pt_y, upper_y);
+        grid_pt_weights[j * 24 + 23] = compute_weight<scalar_t>(pt_z, upper_z);
+    }
+
+    __syncthreads();
+
+    int gvtx_idx = 0;
+    for (int j = index; j < n_pts; j += stride)
+    {
+        // LLL -> Lower X, Lower Y, Lower Z
+        gvtx_idx = grid_pt_indexes[j * 8 + 0];
+        atomicAdd(&(grid_weights[gvtx_idx]), grid_pt_weights[j * 24 + 0] *
+                                                 grid_pt_weights[j * 24 + 1] *
+                                                 grid_pt_weights[j * 24 + 2]);
+        // LLU -> Lower X, Lower Y, Upper Z
+        gvtx_idx = grid_pt_indexes[j * 8 + 1];
+        atomicAdd(&(grid_weights[gvtx_idx]), grid_pt_weights[j * 24 + 3] *
+                                                 grid_pt_weights[j * 24 + 4] *
+                                                 grid_pt_weights[j * 24 + 5]);
+        // LUL -> Lower X, Upper Y, Lower Z
+        gvtx_idx = grid_pt_indexes[j * 8 + 2];
+        atomicAdd(&(grid_weights[gvtx_idx]), grid_pt_weights[j * 24 + 6] *
+                                                 grid_pt_weights[j * 24 + 7] *
+                                                 grid_pt_weights[j * 24 + 8]);
+        // LUU -> Lower X, Upper Y, Upper Z
+        gvtx_idx = grid_pt_indexes[j * 8 + 3];
+        atomicAdd(&(grid_weights[gvtx_idx]), grid_pt_weights[j * 24 + 9] *
+                                                 grid_pt_weights[j * 24 + 10] *
+                                                 grid_pt_weights[j * 24 + 11]);
+        // ULL -> Upper X, Lower Y, Lower Z
+        gvtx_idx = grid_pt_indexes[j * 8 + 4];
+        atomicAdd(&(grid_weights[gvtx_idx]), grid_pt_weights[j * 24 + 12] *
+                                                 grid_pt_weights[j * 24 + 13] *
+                                                 grid_pt_weights[j * 24 + 14]);
+        // ULU -> Upper X, Lower Y, Upper Z
+        gvtx_idx = grid_pt_indexes[j * 8 + 5];
+        atomicAdd(&(grid_weights[gvtx_idx]), grid_pt_weights[j * 24 + 15] *
+                                                 grid_pt_weights[j * 24 + 16] *
+                                                 grid_pt_weights[j * 24 + 17]);
+        // UUL -> Upper X, Upper Y, Lower Z
+        gvtx_idx = grid_pt_indexes[j * 8 + 6];
+        atomicAdd(&(grid_weights[gvtx_idx]), grid_pt_weights[j * 24 + 18] *
+                                                 grid_pt_weights[j * 24 + 19] *
+                                                 grid_pt_weights[j * 24 + 20]);
+        // UUU -> Upper X, Upper Y, Upper Z
+        gvtx_idx = grid_pt_indexes[j * 8 + 7];
+        atomicAdd(&(grid_weights[gvtx_idx]), grid_pt_weights[j * 24 + 21] *
+                                                 grid_pt_weights[j * 24 + 22] *
+                                                 grid_pt_weights[j * 24 + 23]);
+    }
+}
+
+std::vector<torch::Tensor> gridding_kernel_warpper(float min_x, float max_x, float min_y,
+                                                   float max_y, float min_z, float max_z,
+                                                   torch::Tensor ptcloud, cudaStream_t stream)
+{
+    int batch_size = ptcloud.size(0);
+    int n_pts = ptcloud.size(1);
+    int len_x = max_x - min_x + 1;
+    int len_y = max_y - min_y + 1;
+    int len_z = max_z - min_z + 1;
+    int n_grid_vertices = len_x * len_y * len_z;
+
+    torch::Tensor grid_weights =
+        torch::zeros({batch_size, n_grid_vertices}, torch::CUDA(ptcloud.scalar_type()));
+    torch::Tensor grid_pt_weights =
+        torch::zeros({batch_size, n_pts, 8, 3}, torch::CUDA(ptcloud.scalar_type()));
+    torch::Tensor grid_pt_indexes = torch::zeros({batch_size, n_pts, 8}, torch::CUDA(torch::kInt));
+
+    AT_DISPATCH_FLOATING_TYPES(
+        grid_pt_weights.scalar_type(), "gridding_reverse_cuda", ([&] {
+            gridding_kernel<<<batch_size, get_n_threads(n_pts), 0, stream>>>(
+                n_grid_vertices, n_pts, min_x, min_y, min_z, len_y, len_z,
+                ptcloud.data_ptr<scalar_t>(), grid_weights.data_ptr<scalar_t>(),
+                grid_pt_weights.data_ptr<scalar_t>(), grid_pt_indexes.data_ptr<int>());
+        }));
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess)
+    {
+        printf("Error in gridding_kernel_warpper: %s\n", cudaGetErrorString(err));
+    }
+    return {grid_weights, grid_pt_weights, grid_pt_indexes};
+}
+
+template <typename scalar_t>
+__global__ void
+gridding_grad_kernel(int n_grid_vertices, int n_pts, const scalar_t* __restrict__ grid_pt_weights,
+                     const int* __restrict__ grid_pt_indexes,
+                     const scalar_t* __restrict__ grad_grid, scalar_t* __restrict__ grad_ptcloud)
+{
+    int batch_index = blockIdx.x;
+    int index = threadIdx.x;
+    int stride = blockDim.x;
+
+    grid_pt_weights += batch_index * n_pts * 24;
+    grid_pt_indexes += batch_index * n_pts * 8;
+    grad_grid += batch_index * n_grid_vertices;
+    grad_ptcloud += batch_index * n_pts * 3;
+
+    int gvtx_idx = 0;
+    scalar_t grad_vtx = 0, x_weights = 0, y_weights = 0, z_weights = 0;
+    for (int j = index; j < n_pts; j += stride)
+    {
+        // Compute gradient for the corresponding positions, a loop for 8 points
+        // LLL -> Lower X, Lower Y, Lower Z
+        gvtx_idx = grid_pt_indexes[j * 8 + 0];
+        grad_vtx = grad_grid[gvtx_idx];
+        x_weights = grid_pt_weights[j * 24 + 0];
+        y_weights = grid_pt_weights[j * 24 + 1];
+        z_weights = grid_pt_weights[j * 24 + 2];
+        atomicAdd(&(grad_ptcloud[j * 3 + 0]), -grad_vtx * y_weights * z_weights);
+        atomicAdd(&(grad_ptcloud[j * 3 + 1]), -grad_vtx * x_weights * z_weights);
+        atomicAdd(&(grad_ptcloud[j * 3 + 2]), -grad_vtx * x_weights * y_weights);
+
+        // LLU -> Lower X, Lower Y, Upper Z
+        gvtx_idx = grid_pt_indexes[j * 8 + 1];
+        grad_vtx = grad_grid[gvtx_idx];
+        x_weights = grid_pt_weights[j * 24 + 3];
+        y_weights = grid_pt_weights[j * 24 + 4];
+        z_weights = grid_pt_weights[j * 24 + 5];
+        atomicAdd(&(grad_ptcloud[j * 3 + 0]), -grad_vtx * y_weights * z_weights);
+        atomicAdd(&(grad_ptcloud[j * 3 + 1]), -grad_vtx * x_weights * z_weights);
+        atomicAdd(&(grad_ptcloud[j * 3 + 2]), grad_vtx * x_weights * y_weights);
+
+        // LUL -> Lower X, Upper Y, Lower Z
+        gvtx_idx = grid_pt_indexes[j * 8 + 2];
+        grad_vtx = grad_grid[gvtx_idx];
+        x_weights = grid_pt_weights[j * 24 + 6];
+        y_weights = grid_pt_weights[j * 24 + 7];
+        z_weights = grid_pt_weights[j * 24 + 8];
+        atomicAdd(&(grad_ptcloud[j * 3 + 0]), -grad_vtx * y_weights * z_weights);
+        atomicAdd(&(grad_ptcloud[j * 3 + 1]), grad_vtx * x_weights * z_weights);
+        atomicAdd(&(grad_ptcloud[j * 3 + 2]), -grad_vtx * x_weights * y_weights);
+
+        // LUU -> Lower X, Upper Y, Upper Z
+        gvtx_idx = grid_pt_indexes[j * 8 + 3];
+        grad_vtx = grad_grid[gvtx_idx];
+        x_weights = grid_pt_weights[j * 24 + 9];
+        y_weights = grid_pt_weights[j * 24 + 10];
+        z_weights = grid_pt_weights[j * 24 + 11];
+        atomicAdd(&(grad_ptcloud[j * 3 + 0]), -grad_vtx * y_weights * z_weights);
+        atomicAdd(&(grad_ptcloud[j * 3 + 1]), grad_vtx * x_weights * z_weights);
+        atomicAdd(&(grad_ptcloud[j * 3 + 2]), grad_vtx * x_weights * y_weights);
+
+        // ULL -> Upper X, Lower Y, Lower Z
+        gvtx_idx = grid_pt_indexes[j * 8 + 4];
+        grad_vtx = grad_grid[gvtx_idx];
+        x_weights = grid_pt_weights[j * 24 + 12];
+        y_weights = grid_pt_weights[j * 24 + 13];
+        z_weights = grid_pt_weights[j * 24 + 14];
+        atomicAdd(&(grad_ptcloud[j * 3 + 0]), grad_vtx * y_weights * z_weights);
+        atomicAdd(&(grad_ptcloud[j * 3 + 1]), -grad_vtx * x_weights * z_weights);
+        atomicAdd(&(grad_ptcloud[j * 3 + 2]), -grad_vtx * x_weights * y_weights);
+
+        // ULU -> Upper X, Lower Y, Upper Z
+        gvtx_idx = grid_pt_indexes[j * 8 + 5];
+        grad_vtx = grad_grid[gvtx_idx];
+        x_weights = grid_pt_weights[j * 24 + 15];
+        y_weights = grid_pt_weights[j * 24 + 16];
+        z_weights = grid_pt_weights[j * 24 + 17];
+        atomicAdd(&(grad_ptcloud[j * 3 + 0]), grad_vtx * y_weights * z_weights);
+        atomicAdd(&(grad_ptcloud[j * 3 + 1]), -grad_vtx * x_weights * z_weights);
+        atomicAdd(&(grad_ptcloud[j * 3 + 2]), grad_vtx * x_weights * y_weights);
+
+        // UUL -> Upper X, Upper Y, Lower Z
+        gvtx_idx = grid_pt_indexes[j * 8 + 6];
+        grad_vtx = grad_grid[gvtx_idx];
+        x_weights = grid_pt_weights[j * 24 + 18];
+        y_weights = grid_pt_weights[j * 24 + 19];
+        z_weights = grid_pt_weights[j * 24 + 20];
+        atomicAdd(&(grad_ptcloud[j * 3 + 0]), grad_vtx * y_weights * z_weights);
+        atomicAdd(&(grad_ptcloud[j * 3 + 1]), grad_vtx * x_weights * z_weights);
+        atomicAdd(&(grad_ptcloud[j * 3 + 2]), -grad_vtx * x_weights * y_weights);
+
+        // UUU -> Upper X, Upper Y, Upper Z
+        gvtx_idx = grid_pt_indexes[j * 8 + 7];
+        grad_vtx = grad_grid[gvtx_idx];
+        x_weights = grid_pt_weights[j * 24 + 21];
+        y_weights = grid_pt_weights[j * 24 + 22];
+        z_weights = grid_pt_weights[j * 24 + 23];
+        atomicAdd(&(grad_ptcloud[j * 3 + 0]), grad_vtx * y_weights * z_weights);
+        atomicAdd(&(grad_ptcloud[j * 3 + 1]), grad_vtx * x_weights * z_weights);
+        atomicAdd(&(grad_ptcloud[j * 3 + 2]), grad_vtx * x_weights * y_weights);
+    }
+}
+
+torch::Tensor gridding_grad_kernel_warpper(torch::Tensor grid_pt_weights,
+                                           torch::Tensor grid_pt_indexes, torch::Tensor grad_grid,
+                                           cudaStream_t stream)
+{
+    int batch_size = grad_grid.size(0);
+    int n_grid_vertices = grad_grid.size(1);
+    int n_pts = grid_pt_indexes.size(1);
+
+    torch::Tensor grad_ptcloud =
+        torch::zeros({batch_size, n_pts, 3}, torch::CUDA(grid_pt_weights.scalar_type()));
+
+    AT_DISPATCH_FLOATING_TYPES(
+        grid_pt_weights.scalar_type(), "gridding_reverse_grad_cuda", ([&] {
+            gridding_grad_kernel<<<batch_size, get_n_threads(n_pts), 0, stream>>>(
+                n_grid_vertices, n_pts, grid_pt_weights.data_ptr<scalar_t>(),
+                grid_pt_indexes.data_ptr<int>(), grad_grid.data_ptr<scalar_t>(),
+                grad_ptcloud.data_ptr<scalar_t>());
+        }));
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess)
+    {
+        printf("Error in gridding_grad_kernel_warpper: %s\n", cudaGetErrorString(err));
+    }
+    return grad_ptcloud;
+}

--- a/test/test_gridding.py
+++ b/test/test_gridding.py
@@ -27,4 +27,3 @@ class TestGridding(unittest.TestCase):
         x = torch.rand(1, 64, 3)
         x.requires_grad = True
         self.assertTrue(gradcheck(GriddingFunction.apply, [x.double().cuda(), 8]))
-

--- a/test/test_gridding_reverse.py
+++ b/test/test_gridding_reverse.py
@@ -1,0 +1,23 @@
+import numpy as np
+import os
+import sys
+import torch
+import unittest
+
+from torch.autograd import gradcheck
+
+from . import run_if_cuda
+
+
+ROOT = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
+sys.path.insert(0, ROOT)
+
+from torch_points_kernels.gridding_reverse import GriddingReverseFunction
+
+
+class TestGridding(unittest.TestCase):
+    @run_if_cuda
+    def test_gridding_reverse_function_r8(self):
+        x = torch.rand(4, 8, 8, 8)
+        x.requires_grad = True
+        self.assertTrue(gradcheck(GriddingReverseFunction.apply, [x.double().cuda(), 8]))

--- a/torch_points_kernels/__init__.py
+++ b/torch_points_kernels/__init__.py
@@ -2,7 +2,10 @@ from .torchpoints import *
 from .knn import knn
 from .cluster import region_grow
 from .metrics import instance_iou
+from .chamfer_dist import chamfer_dist
 from .cubic_feature_sampling import cubic_feature_sampling
+from .gridding import gridding
+from .gridding_reverse import gridding_reverse
 
 __all__ = [
     "ball_query",
@@ -16,4 +19,5 @@ __all__ = [
     "chamfer_dist",
     "cubic_feature_sampling",
     "gridding",
+    "gridding_reverse",
 ]

--- a/torch_points_kernels/gridding.py
+++ b/torch_points_kernels/gridding.py
@@ -8,7 +8,7 @@ class GriddingFunction(torch.autograd.Function):
     @staticmethod
     def forward(ctx, ptcloud, scale):
         if not torch.cuda.is_available():
-            raise NotImplementedError("CPU version is not available for Chamfer Distance")
+            raise NotImplementedError("CPU version is not available for Gridding")
 
         grid, grid_pt_weights, grid_pt_indexes = tpcuda.gridding(
             -scale, scale - 1, -scale, scale - 1, -scale, scale - 1, ptcloud

--- a/torch_points_kernels/gridding_reverse.py
+++ b/torch_points_kernels/gridding_reverse.py
@@ -1,0 +1,44 @@
+import torch
+
+if torch.cuda.is_available():
+    import torch_points_kernels.points_cuda as tpcuda
+
+
+class GriddingReverseFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, grid, scale):
+        if not torch.cuda.is_available():
+            raise NotImplementedError("CPU version is not available for Gridding Reverse")
+
+        ptcloud = tpcuda.gridding_reverse(scale, grid)
+        ctx.save_for_backward(torch.Tensor([scale]), grid, ptcloud)
+        return ptcloud
+
+    @staticmethod
+    def backward(ctx, grad_ptcloud):
+        scale, grid, ptcloud = ctx.saved_tensors
+        scale = int(scale.item())
+        grad_grid = tpcuda.gridding_reverse_grad(ptcloud, grid, grad_ptcloud)
+        grad_grid = grad_grid.view(-1, scale, scale, scale)
+        return grad_grid, None
+
+
+def gridding_reverse(grid, scale):
+    r"""
+    Converts the input point clouds into 3D grids by trilinear interpolcation.
+    Please refer to https://arxiv.org/pdf/2006.03761 for more information
+
+    Parameters
+    ----------
+    grid: torch.Tensor (dtype=torch.float32)
+        (B, scale, scale, scale): the 3D grid of the resolution of scale * scale * scale
+    scale : Int
+        the resolution of the 3D grid
+
+    Returns
+    -------
+    grid: torch.Tensor (dtype=torch.float32)
+        (B, n_pts, 3) B point clouds containing n_pts points
+    """
+    ptcloud = GriddingReverseFunction.apply(grid, scale)
+    return ptcloud / scale * 2


### PR DESCRIPTION
Hi, @nicolas-chaulet 

The compiler says:

```
/usr/bin/ld: build/temp.linux-x86_64-3.8/cuda/src/gridding_gpu.o: in function `compute_index(int, int, int, int, int)':
tmpxft_003a9dfe_00000000-5_gridding_gpu.cudafe1.cpp:(.text+0x180): multiple definition of `compute_index(int, int, int, int, int)'; build/temp.linux-x86_64-3.8/cuda/src/gridding_reverse_gpu.o:tmpxft_003a9d70_00000000-5_gridding_reverse_gpu.cudafe1.cpp:(.text+0x180): first defined here
```

However, other functions (e.g., compute_weights, get_n_threads) do not have the same issue.
I tried to put it into a header file (`*.h`) and include it in `gridding_gpu.cu` and `gridding_reverse_gpu.cu`. But the problem still exists.
Can you help me to solve this problem?