### PR TITLE
Add manual CUDA/GCC/g++ path specification

### DIFF
--- a/conda/torch-points-kernels/README.md
+++ b/conda/torch-points-kernels/README.md
@@ -1,3 +1,18 @@
+## Usage
 ```
-./build_conda.sh 3.9 1.9.0 cu111  # python, pytorch and cuda version
+./build_conda.sh python, pytorch, cuda version, [cuda_home path, gcc path, g++ path]
+```
+## Example
+```
+./build_conda.sh 3.9 1.9.0 cu111 #assume CUDA installation by current environment variables
+./build_conda.sh 3.9 1.9.0 cu111 /usr/local/cuda /usr/bin/gcc /usr/bin/g++ #Ubuntu
+./build_conda.sh 3.8 1.10.2 cu102 /opt/cuda-10.2/ /opt/cuda-10.2/bin/gcc /opt/cuda-10.2/bin/g++ #Arch Linux uses /opt/
+```
+
+## Notes
+Your gcc and g++ versions must match the correct version of CUDA you are trying to build for. See [this table](https://stackoverflow.com/a/46380601/8724072) for valid configurations. To check your CUDA, GCC and g++ versions, run the following commands respectively. If they do not match you will need to install another version and specify the paths manually as shown above.
+```
+nvcc --version
+gcc --version
+g++ --version
 ```

--- a/conda/torch-points-kernels/build_conda.sh
+++ b/conda/torch-points-kernels/build_conda.sh
@@ -4,6 +4,24 @@ export PYTHON_VERSION=$1
 export TORCH_VERSION=$2
 export CUDA_VERSION=$3
 
+
+# CUDA_HOME needs to be set to build this package but sometimes it is incorrectly set to an incompatible version when the build environment is created.
+# This is the case if the system has multiple CUDA installations and/or an incompatible version (not 10.1, 10.2, 11.1) is the default. Rolling release Linux distributions do this.
+# A solution is to accept a optional path to the correct CUDA installation.
+if [ -z "$4" ]; then
+  export CUDA_HOME=$4
+  
+  # Also need to set gcc and g++ versions to the matching CUDA version. See the table in https://stackoverflow.com/a/46380601/8724072
+  export CC=$5
+  export CXX=$6
+
+else
+  echo "Using default CUDA_HOME="$CUDA_HOME
+
+fi
+
+
+
 export CONDA_PYTORCH_CONSTRAINT="pytorch==${TORCH_VERSION%.*}.*"
 
 if [ "${CUDA_VERSION}" = "cpu" ]; then
@@ -30,4 +48,4 @@ echo "PyTorch $TORCH_VERSION+$CUDA_VERSION"
 echo "- $CONDA_PYTORCH_CONSTRAINT"
 echo "- $CONDA_CUDATOOLKIT_CONSTRAINT"
 
-conda build . -c defaults -c pytorch -c conda-forge -c rusty1s --output-folder "$HOME/conda-bld"
+conda build . -c pytorch -c defaults -c conda-forge -c rusty1s --output-folder "$HOME/conda-bld"

--- a/conda/torch-points-kernels/conda_build_config.yaml
+++ b/conda/torch-points-kernels/conda_build_config.yaml
@@ -1,2 +1,2 @@
 channel_sources:
-  - conda-forge,defaults
+  - pytorch,conda-forge,defaults

--- a/conda/torch-points-kernels/conda_build_config.yaml
+++ b/conda/torch-points-kernels/conda_build_config.yaml
@@ -1,2 +1,3 @@
 channel_sources:
   - pytorch,conda-forge,defaults
+numpy: '1.21.5'

--- a/conda/torch-points-kernels/meta.yaml
+++ b/conda/torch-points-kernels/meta.yaml
@@ -28,6 +28,9 @@ build:
   script: pip install .
   script_env:
     - FORCE_CUDA
+    - CUDA_HOME={{ environ.get('CUDA_HOME') }}
+    - CC={{ environ.get('CC') }}
+    - CXX={{ environ.get('CXX') }}
 
 test:
   imports:


### PR DESCRIPTION
This PR adds the option to manually specify the locations of the CUDA, GCC and g++ folders which are needed to build. These changes should resolve any issues people had (like myself) where there CUDA version used in a conda environment is different from the system default.