### PR TITLE
add missing <memory> header to allow building with GCC12

### DIFF
--- a/cpu/src/neighbors.cpp
+++ b/cpu/src/neighbors.cpp
@@ -3,6 +3,7 @@
 
 #include "neighbors.h"
 #include <chrono>
+#include <memory>
 #include <random>
 
 template <typename scalar_t>


### PR DESCRIPTION
Some C++ Standard Library headers have been changed to no longer include other headers that were being used internally by the library since GCC12[^1].  As a result, building torch-points-kernels with GCC12 fails with message:

      cpu/src/neighbors.cpp:317:10: error: ‘unique_ptr’ is not a member of ‘std’
        317 |     std::unique_ptr<my_kd_tree_t> index(new my_kd_tree_t(3, pcd, tree_params));
            |          ^~~~~~~~~~
      cpu/src/neighbors.cpp:317:10: note: ‘std::unique_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?

This pr adds the missing `<memory>` header to `cpu/src/neighbors.cpp` to allow building with GCC12.

[^1]: <https://gcc.gnu.org/gcc-12/porting_to.html#header-dep-changes>

Signed-off-by: Gaoyang Zhang <gy@blurgy.xyz>